### PR TITLE
[fix] Enhance logging and optimize prompt handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="weavel",
-    version="1.10.0",
+    version="1.10.1",
     packages=find_namespace_packages(),
     entry_points={},
     description="Weavel, Prompt Optimization and Evaluation for LLM Applications",

--- a/weavel/client.py
+++ b/weavel/client.py
@@ -1089,4 +1089,4 @@ class Weavel:
 
                 logger.info("Optimization complete!")
                 logger.info(f"View all prompts at: {res["url"]}")
-                return res["optimized_prompt"]
+                return Prompt(**res["optimized_prompt"])

--- a/weavel/utils/logging.py
+++ b/weavel/utils/logging.py
@@ -10,34 +10,72 @@ from rich.theme import Theme
 
 console = Console(width=200, theme=Theme({"logging.level": "bold"}))
 
+LOGGER_NAME = "weavel"
+
 
 class TypedBoundLogger(structlog.stdlib.BoundLogger):
-    def msg(self, message: str, **kwargs: t.Any) -> None:
-        """Log a message."""
-        self._proxy_to_logger("msg", message, **kwargs)
+    def msg(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
+        """Log a message.
 
-    def debug(self, event: str, **kwargs: t.Any) -> None:
-        """Log a debug message."""
-        self._proxy_to_logger("debug", event, **kwargs)
+        Args:
+            event (str): The main log message or event description.
+            *args: Additional positional arguments to be logged.
+            **kwargs: Additional keyword arguments to be logged.
+        """
+        self._proxy_to_logger("msg", event, *args, **kwargs)
 
-    def info(self, event: str, **kwargs: t.Any) -> None:
-        """Log an info message."""
-        self._proxy_to_logger("info", event, **kwargs)
+    def debug(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
+        """Log a debug message.
 
-    def warning(self, event: str, **kwargs: t.Any) -> None:
-        """Log a warning message."""
-        self._proxy_to_logger("warning", event, **kwargs)
+        Args:
+            event (str): The main log message or event description.
+            *args: Additional positional arguments to be logged.
+            **kwargs: Additional keyword arguments to be logged.
+        """
+        self._proxy_to_logger("debug", event, *args, **kwargs)
 
-    def error(self, event: str, **kwargs: t.Any) -> None:
-        """Log an error message."""
-        self._proxy_to_logger("error", event, **kwargs)
+    def info(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
+        """Log an info message.
 
-    def critical(self, event: str, **kwargs: t.Any) -> None:
-        """Log a critical message."""
-        self._proxy_to_logger("critical", event, **kwargs)
+        Args:
+            event (str): The main log message or event description.
+            *args: Additional positional arguments to be logged.
+            **kwargs: Additional keyword arguments to be logged.
+        """
+        self._proxy_to_logger("info", event, *args, **kwargs)
+
+    def warning(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
+        """Log a warning message.
+
+        Args:
+            event (str): The main log message or event description.
+            *args: Additional positional arguments to be logged.
+            **kwargs: Additional keyword arguments to be logged.
+        """
+        self._proxy_to_logger("warning", event, *args, **kwargs)
+
+    def error(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
+        """Log an error message.
+
+        Args:
+            event (str): The main log message or event description.
+            *args: Additional positional arguments to be logged.
+            **kwargs: Additional keyword arguments to be logged.
+        """
+        self._proxy_to_logger("error", event, *args, **kwargs)
+
+    def critical(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
+        """Log a critical message.
+
+        Args:
+            event (str): The main log message or event description.
+            *args: Additional positional arguments to be logged.
+            **kwargs: Additional keyword arguments to be logged.
+        """
+        self._proxy_to_logger("critical", event, *args, **kwargs)
 
 
-logger: TypedBoundLogger = structlog.get_logger("weavel")
+logger: TypedBoundLogger = structlog.get_logger(LOGGER_NAME)
 
 
 class LogSettings:
@@ -107,7 +145,7 @@ class LogSettings:
         self._configure_structlog()
 
         # Grab the weavel logger
-        log = logging.getLogger("weavel")
+        log = logging.getLogger(LOGGER_NAME)
         for handler in log.handlers[:]:
             log.removeHandler(handler)
 
@@ -133,12 +171,13 @@ level = os.environ.get("WEAVEL_LOG_LEVEL", "info").upper()
 
 # Set Defaults
 def show_logging(level: str = level) -> None:
-    weavel_logger = logging.getLogger("weavel")
+    weavel_logger = logging.getLogger(LOGGER_NAME)
     weavel_logger.setLevel(level)
     weavel_logger.handlers = [
         RichHandler(console=console, rich_tracebacks=True, markup=True)
     ]
 
 
+show_logging(level)
 settings = LogSettings(output_type="str", method="console", file_name=None)
 set_log_output = settings.set_log_output

--- a/weavel/utils/logging.py
+++ b/weavel/utils/logging.py
@@ -13,69 +13,7 @@ console = Console(width=200, theme=Theme({"logging.level": "bold"}))
 LOGGER_NAME = "weavel"
 
 
-class TypedBoundLogger(structlog.stdlib.BoundLogger):
-    def msg(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
-        """Log a message.
-
-        Args:
-            event (str): The main log message or event description.
-            *args: Additional positional arguments to be logged.
-            **kwargs: Additional keyword arguments to be logged.
-        """
-        self._proxy_to_logger("msg", event, *args, **kwargs)
-
-    def debug(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
-        """Log a debug message.
-
-        Args:
-            event (str): The main log message or event description.
-            *args: Additional positional arguments to be logged.
-            **kwargs: Additional keyword arguments to be logged.
-        """
-        self._proxy_to_logger("debug", event, *args, **kwargs)
-
-    def info(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
-        """Log an info message.
-
-        Args:
-            event (str): The main log message or event description.
-            *args: Additional positional arguments to be logged.
-            **kwargs: Additional keyword arguments to be logged.
-        """
-        self._proxy_to_logger("info", event, *args, **kwargs)
-
-    def warning(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
-        """Log a warning message.
-
-        Args:
-            event (str): The main log message or event description.
-            *args: Additional positional arguments to be logged.
-            **kwargs: Additional keyword arguments to be logged.
-        """
-        self._proxy_to_logger("warning", event, *args, **kwargs)
-
-    def error(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
-        """Log an error message.
-
-        Args:
-            event (str): The main log message or event description.
-            *args: Additional positional arguments to be logged.
-            **kwargs: Additional keyword arguments to be logged.
-        """
-        self._proxy_to_logger("error", event, *args, **kwargs)
-
-    def critical(self, event: str, *args: t.Any, **kwargs: t.Any) -> None:
-        """Log a critical message.
-
-        Args:
-            event (str): The main log message or event description.
-            *args: Additional positional arguments to be logged.
-            **kwargs: Additional keyword arguments to be logged.
-        """
-        self._proxy_to_logger("critical", event, *args, **kwargs)
-
-
-logger: TypedBoundLogger = structlog.get_logger(LOGGER_NAME)
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(LOGGER_NAME)
 
 
 class LogSettings:
@@ -105,7 +43,7 @@ class LogSettings:
                 renderer,
             ],
             logger_factory=structlog.stdlib.LoggerFactory(),
-            wrapper_class=TypedBoundLogger,
+            wrapper_class=structlog.stdlib.BoundLogger,
             cache_logger_on_first_use=True,
         )
 


### PR DESCRIPTION
- Return Prompt object instead of dictionary in optimize_prompt method
- Replace custom TypedBoundLogger with standard structlog.stdlib.BoundLogger
- Introduce LOGGER_NAME constant for consistency
- Add default logging setup with show_logging(level)
- Upgrade package version from 1.10.0 to 1.10.1 in setup.py
- Simplify logger configuration process

Notes: The changes in weavel/client.py aim to return a Prompt object instead of a dictionary, as it can be used directly with Evaluate or as a callable. This improves the functionality and usability of the optimize_prompt method, but may break backward compatibility for code expecting a dictionary return value. The logging modifications in weavel/utils/logging.py enhance the logging setup by replacing the custom TypedBoundLogger, improving consistency with the LOGGER_NAME constant, and setting up default logging behavior. These changes aim to improve code maintainability and enhance logging capabilities.

*Created with [Palmier](https://www.palmier.io)*